### PR TITLE
Refactored produce & metadata methods

### DIFF
--- a/lib/Net/Kafka.pm
+++ b/lib/Net/Kafka.pm
@@ -85,7 +85,7 @@ BEGIN {
 sub partitions_for {
     my ($self, $topic, $timeout_ms) = @_;
     $timeout_ms //= DEFAULT_METADATA_TIMEOUT;
-    my $metadata = $self->metadata($self->topic($topic), $timeout_ms);
+    my $metadata = $self->topic($topic)->metadata($timeout_ms);
     my @topics   = grep { $_->{topic_name} eq $topic } @{ $metadata->{topics} };
     die sprintf("Unable to fetch metadata for topic %s", $topic)
         if scalar @topics != 1;

--- a/t/01-producer.t
+++ b/t/01-producer.t
@@ -16,7 +16,7 @@ subtest 'Partitions For' => sub {
     my $producer = TestProducer->new();
     my $partitions = $producer->partitions_for( TestProducer::topic );
     isa_ok($partitions, 'ARRAY');
-    is (scalar(@$partitions), TestProducer::topic_partitions, "fetch partitions info");
+    is (scalar(@$partitions), TestProducer::topic_partitions(), "fetch partitions info");
 };
 
 subtest 'Partitions For (missing topic)' => sub {


### PR DESCRIPTION
- Moved `metadata` method into `Net::Kafka::Topic` object definition for easier method chaining
- Moved `produce` method from `Net::Kafka::Topic` into `Net::Kafka` object definition, since we don't need `rd_kafka_topic_t*` pointer to produce a message anymore
- Removed leaky local caches of `_topics` in both Producer and Consumer