### PR TITLE
Remove dependency on Perl 5.22

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,3 @@
-use 5.22.0;
 use strict;
 use warnings;
 
@@ -62,7 +61,7 @@ WriteMakefile(
             },
         },
     },
-    MIN_PERL_VERSION    => '5.22.0',
+    MIN_PERL_VERSION    => '5.10.0',
     CONFIGURE_REQUIRES  => {
         'ExtUtils::MakeMaker' => 0,
         'ExtUtils::PkgConfig' => 0,


### PR DESCRIPTION
Running `perlverl` from `Perl::MinimumVersion` on this module shows that all Perl features used in this code work are available as far back as Perl 5.10. This relaxes the version requirement, and makes this available to a larger audience.