### PR TITLE
Fix FTBFS on 32-bit with gcc 14

### DIFF
--- a/Kafka.xs
+++ b/Kafka.xs
@@ -418,7 +418,7 @@ krd_query_watermark_offsets(rdk, topic, partition, timeout_ms)
         long timeout_ms
     PREINIT:
         rd_kafka_resp_err_t err;
-        long low, high;
+        int64_t low, high;
     PPCODE:
         err = rd_kafka_query_watermark_offsets(rdk->rk, topic, partition, &low, &high, timeout_ms);
         if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {


### PR DESCRIPTION

In Debian we are currently applying the following patch to Net-Kafka.
We thought you might be interested in it too.

    Description: Fix FTBFS on 32-bit with gcc 14
    Bug-Debian: https://bugs.debian.org/1085145
    Author: Adrian Bunk <bunk@debian.org>
    Reviewed-by: gregor herrmann <gregoa@debian.org>
    Last-Update: 2024-10-15
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libnet-kafka-perl/raw/master/debian/patches/gcc-14.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
